### PR TITLE
Add log file as one of telemetry backend.

### DIFF
--- a/examples/mio_telemetry_test.c
+++ b/examples/mio_telemetry_test.c
@@ -16,10 +16,11 @@
 #include "obj.h"
 #include "helpers.h"
 
-static void telem_usage(FILE *file, char *prog_name)
-{
-	fprintf(file, "Usage: %s Test telemetry APIs.\n", prog_name);
-}
+/**
+ * MIO telemetry tests with log as backend. The tests also
+ * show how to use telemetry APIs without Motr or other storage
+ * drivers.
+ */
 
 void telem_tests()
 {
@@ -76,11 +77,12 @@ void telem_tests()
 int main(int argc, char **argv)
 {
 	int rc;
-	struct mio_cmd_obj_params telem_params;
+	struct mio_telemetry_conf telem_conf;
 
-	mio_cmd_obj_args_init(argc, argv, &telem_params, &telem_usage);
-
-	rc = mio_init(telem_params.cop_conf_fname);
+	memset(&telem_conf, 0, sizeof telem_conf);
+	telem_conf.mtc_type = MIO_TM_ST_LOG;
+	telem_conf.mtc_is_parser = false;
+	rc = mio_telemetry_init(&telem_conf);
 	if (rc < 0) {
 		mio_cmd_error("Initialising MIO failed", rc);
 		exit(EXIT_FAILURE);
@@ -88,8 +90,7 @@ int main(int argc, char **argv)
 
 	telem_tests();
 
-	mio_fini();
-	mio_cmd_obj_args_fini(&telem_params);
+	mio_telemetry_fini();
 	return rc;
 }
 

--- a/src/Makefile.sub
+++ b/src/Makefile.sub
@@ -13,7 +13,7 @@ nobase_mio_include_HEADERS += src/mio.h \
 
 lib_libmio_la_SOURCES += src/mio_conf.c src/logger.c src/utils.c \
 			 src/mio.c src/mio_driver.c src/hints.c \
-			 src/mio_telemetry.c \
+			 src/mio_telemetry.c src/telemetry_log.c \
 			 src/driver_motr.c src/driver_motr_obj.c \
 			 src/driver_motr_kvs.c src/driver_motr_comp_obj.c \
 			 src/driver_motr_addb.c

--- a/src/logger.c
+++ b/src/logger.c
@@ -10,47 +10,161 @@
 
 #include <errno.h>
 #include <string.h>
+#include <time.h>
+#include <unistd.h>	
+#include <assert.h>
 
 #include "logger.h"
 #include "mio_internal.h"
 
-enum mio_log_level mio_log_level = MIO_INFO;
-
-struct {
-	const char *name;
-} mio_log_levels[] = {
+struct mio_log_level_name mio_log_levels[] = {
         [MIO_ERROR]	= {"error"},
         [MIO_WARN]	= {"warning"},
         [MIO_INFO]	= {"info"},
         [MIO_TRACE]	= {"trace"},
+        [MIO_TELEMETRY]	= {"telem"},
         [MIO_DEBUG]	= {"debug"},
 };
 
-static FILE *mio_log_file;
+enum mio_log_level mio_log_level = MIO_INFO;
+FILE *mio_log_file = NULL;
+static int bytes_since_flush = 0;
+
+static int log_time(char *time_buf, int len, bool is_fname)
+{
+	int rc;
+	uint64_t now;
+	time_t time_secs;
+	uint64_t time_nanosecs;
+	struct tm tm;
+
+	now = mio_now();
+	time_secs = mio_time_seconds(now);
+	time_nanosecs = mio_time_nanoseconds(now);
+	localtime_r(&time_secs, &tm);
+
+	if (is_fname)
+		rc = snprintf(time_buf, len,
+			      "%04d-%02d-%02d-%02d-%02d-%02d",
+			      1900 + tm.tm_year, tm.tm_mon, tm.tm_mday,
+			      tm.tm_hour, tm.tm_min, tm.tm_sec);
+	else
+		rc = snprintf(time_buf, len,
+			      "%04d-%02d-%02d-%02d:%02d:%02d.%09"PRIu64,
+			      1900 + tm.tm_year, tm.tm_mon, tm.tm_mday,
+			      tm.tm_hour, tm.tm_min, tm.tm_sec, time_nanosecs);
+	if (rc > len)
+		return -E2BIG;
+	else
+		return 0;
+}
 
 void mio_log(enum mio_log_level lev, const char *fmt, ...)
 {
+	int rc;
         va_list va;
+	char log_rec[MIO_LOG_MAX_REC_LEN];
+	char timestamp[MIO_LOG_MAX_TIMESTAMP_LEN];
+	char *log_rec_ptr = log_rec;
+	int head_len;
+	int time_len;
+	int log_rec_len;
+
 	va_start(va, fmt);
-	fprintf(mio_log_file, "%s: ", mio_log_levels[lev].name);
-	vfprintf(mio_log_file, fmt, va);
+
+	head_len = strlen(mio_log_levels[lev].name) + 3; 
+	assert(head_len < MIO_LOG_MAX_REC_LEN);
+	snprintf(log_rec_ptr, head_len, "[%s]", mio_log_levels[lev].name);
+	log_rec_ptr += head_len - 1;
+	*log_rec_ptr = ' ';
+	log_rec_ptr += 1;
+
+	rc = log_time(timestamp, MIO_LOG_MAX_TIMESTAMP_LEN, false);
+	if (rc < 0 || strlen(timestamp) > MIO_LOG_MAX_REC_LEN - head_len) {
+		fprintf(stderr, "Timestamp is too log! How is it possible?\n");
+		return;
+	}
+	time_len = strlen(timestamp);
+	mio_mem_copy(log_rec_ptr, timestamp, time_len);
+	log_rec_ptr += time_len;
+	*log_rec_ptr = ' ';
+	log_rec_ptr += 1;
+
+	rc = vsnprintf(log_rec_ptr,
+		       MIO_LOG_MAX_REC_LEN - (log_rec_ptr - log_rec), fmt, va);
+	if (rc >= MIO_LOG_MAX_REC_LEN - (log_rec_ptr - log_rec))
+		fprintf(stderr, "Log record is too big!\n");
+		
 	va_end(va);
 
+	log_rec_len = strlen(log_rec);
+	rc = fwrite(log_rec, log_rec_len, 1, mio_log_file);
+	if (rc != 1) {
+		fprintf(stderr, "Failed writing to log file!\n");
+		return;
+	}
+	bytes_since_flush += log_rec_len;
+	if (bytes_since_flush < MIO_LOG_MAX_BYTES_TO_FLUSH)
+		return;
+	fflush(mio_log_file);
+
+	return;
 }
 
-int mio_log_init(enum mio_log_level level, char *logfile)
+static int mio_log_new(FILE **fp, char *logdir)
 {
-	FILE *fp;
+	int rc;
+	FILE *new_fp = NULL;
+	char log_fname[MIO_LOG_MAX_FNAME_LEN];
+	char timestamp[MIO_LOG_MAX_TIMESTAMP_LEN];
+	pid_t pid;
+	char cwd[PATH_MAX + 1];
+	char *dir;
+#if defined(_GNU_SOURCE)
+	const char *appname = program_invocation_short_name;
+#else
+	const char *appname = "mio-app";
+#endif
 
-	if (logfile != NULL) {
-		fp = fopen(logfile, "w");
-		if (fp == NULL) {
-			fprintf(stderr,
-				"Cann't open log file %s (%d)\n", logfile, errno);
+	rc = log_time(timestamp, MIO_LOG_MAX_TIMESTAMP_LEN, true);
+	if (rc < 0)
+		return rc;
+	pid = getpid();
+	if (logdir == NULL) {
+		dir = getcwd(cwd, PATH_MAX);
+		if (dir == NULL)
 			return -errno;
-		}
 	} else
-		fp = stderr;
+		dir = logdir;
+	sprintf(log_fname, "%s/%s-%d-%s.log",
+		dir, appname, pid, timestamp);
+
+	new_fp = fopen(log_fname, "w+");
+	if (new_fp == NULL) {
+		fprintf(stderr, "Cann't create new log file: %d\n",
+			-errno);
+		*fp = NULL;
+		return -errno;
+	} else {
+		*fp = new_fp;
+		return 0;
+	}
+}
+
+int mio_log_init(enum mio_log_level level, char *logdir)
+{
+	int rc = 0;
+	FILE *fp = NULL;
+
+	/*
+	 * Create a new log file using the following format:
+	 * mio-PID-YY-MM-DAY-TIME.log under the `logdir` directory.
+	 * If logdir == NULL, a new log file is created under current
+	 * working directory.
+	 */
+	rc = mio_log_new(&fp, logdir);
+	if (rc < 0)
+		return rc;
 
 	mio_log_level = level;
 	mio_log_file  = fp;

--- a/src/logger.h
+++ b/src/logger.h
@@ -10,20 +10,38 @@
 #include <stdarg.h>       /* va_list */
 #include <stdio.h>        /* vfprintf(), stderr */
 
+enum {
+	MIO_LOG_MAX_FNAME_LEN = 256,
+	MIO_LOG_MAX_REC_LEN = 1024,
+	MIO_LOG_MAX_TIMESTAMP_LEN = 64,
+	MIO_LOG_MAX_BYTES_TO_FLUSH = 4 * 1024 * 1024,
+};
+
 enum mio_log_level {
 	MIO_LOG_INVALID = -1,
 	MIO_ERROR	= 0,
 	MIO_WARN	= 1,
 	MIO_INFO	= 2,
 	MIO_TRACE	= 3,
-	MIO_DEBUG	= 4,
+	MIO_TELEMETRY   = 4,
+	MIO_DEBUG	= 5,
 	MIO_MAX_LEVEL,
 };
 
+struct mio_log_level_name {
+	const char *name;
+};
+extern struct mio_log_level_name mio_log_levels[];
+
+extern enum mio_log_level mio_log_level;
+extern FILE *mio_log_file;
+
+/**
+ * Logging APIs.
+ */
 int mio_log_init(enum mio_log_level level, char *logfile);
 void mio_log(enum mio_log_level lev, const char *fmt, ...)
 	__attribute__((format(printf, 2, 3)));
-//void mio_set_debug_level(enum mio_log_level level);
 
 #define mio_log_ex(lev, fmt, args...) \
 	mio_log(lev, "%s:%d "fmt, __FUNCTION__, __LINE__, ##args)

--- a/src/mio.c
+++ b/src/mio.c
@@ -866,6 +866,7 @@ bool mio_obj_pool_id_cmp(struct mio_pool_id *pool_id1,
 int mio_init(const char *yaml_conf)
 {
 	int rc;
+	struct mio_telemetry_conf telem_conf;
 
 	mio_instance = mio_mem_alloc(sizeof *mio_instance);
 	if (mio_instance == NULL)
@@ -887,7 +888,7 @@ int mio_init(const char *yaml_conf)
 		goto error;
 	}
 
-	rc = mio_log_init(mio_instance->m_log_level, mio_instance->m_log_file);
+	rc = mio_log_init(mio_instance->m_log_level, mio_instance->m_log_dir);
 	if (rc < 0) {
 		fprintf(stderr, "Failed to initialise logging sub-system. \n");
 		goto error;
@@ -899,7 +900,11 @@ int mio_init(const char *yaml_conf)
 		goto error;
 	}
 
-	rc = mio_telemetry_init(mio_instance->m_telem_store_type);
+	mio_memset(&telem_conf, 0, sizeof telem_conf);
+	telem_conf.mtc_type = mio_instance->m_telem_store_type;
+	if (telem_conf.mtc_type == MIO_TM_ST_LOG)
+		telem_conf.mtc_store_conf = mio_instance->m_log_dir;
+	rc = mio_telemetry_init(&telem_conf);
 	if (rc < 0) {
 		mio_log(MIO_ERROR, "Initialising MIO telemetry failed!\n");
 		goto error;

--- a/src/mio.h
+++ b/src/mio.h
@@ -798,7 +798,7 @@ struct mio {
 	enum mio_telemetry_store_type m_telem_store_type;
 	
 	enum mio_log_level m_log_level;
-	char *m_log_file;
+	char *m_log_dir;
 
 	enum mio_driver_id m_driver_id;
 	struct mio_driver *m_driver;

--- a/src/mio_conf.c
+++ b/src/mio_conf.c
@@ -38,7 +38,7 @@ enum conf_key {
 	/* MIO */
 	MIO_CONFIG = 0,
 	MIO_LOG_LEVEL,
-	MIO_LOG_FILE,
+	MIO_LOG_DIR,
 	MIO_DRIVER,
 	MIO_TELEMETRY_STORE,
 
@@ -85,8 +85,8 @@ struct conf_entry conf_table[] = {
 		.name = "MIO_CONFIG",
 		.type = MIO
 	},
-	[MIO_LOG_FILE] = {
-		.name = "MIO_LOG_FILE",
+	[MIO_LOG_DIR] = {
+		.name = "MIO_LOG_DIR",
 		.type = MIO
 	},
 	[MIO_LOG_LEVEL] = {
@@ -221,7 +221,7 @@ static enum mio_driver_id conf_get_driver_id(const char *str)
 static enum mio_telemetry_store_type
 conf_get_telem_store_type(const char *str)
 {
-	enum mio_telemetry_store_type type = MIO_TM_ST_INVALID;
+	enum mio_telemetry_store_type type = MIO_TM_ST_NONE;
 
 	assert(str != NULL);
 	if (!strcmp(str, "ADDB"))
@@ -243,6 +243,8 @@ static enum mio_log_level conf_get_log_level(const char *str)
 		return MIO_INFO;
 	else if (!strcmp(str, "MIO_TRACE"))
 		return MIO_TRACE;
+	else if (!strcmp(str, "MIO_TELEMETRY"))
+		return MIO_TELEMETRY;
 	else if (!strcmp(str, "MIO_DEBUG"))
 		return MIO_DEBUG;
 	else
@@ -445,9 +447,9 @@ static int conf_extract_value(enum conf_key key, char *value)
 		if (mio_instance->m_log_level == MIO_LOG_INVALID)
 			rc = -EINVAL;
 		break;
-	case MIO_LOG_FILE:
+	case MIO_LOG_DIR:
 		assert(mio_instance != NULL && value != NULL);
-		rc = conf_copy_str(&mio_instance->m_log_file, value);
+		rc = conf_copy_str(&mio_instance->m_log_dir, value);
 		break;
 	case MOTR_INST_ADDR:
 		rc = conf_copy_str(&motr_conf->mc_motr_local_addr, value);

--- a/src/mio_internal.h
+++ b/src/mio_internal.h
@@ -394,6 +394,8 @@ void mio_memset(void *p, int c, size_t size);
 void mio_mem_copy(void *to, void *from, size_t size);
 
 uint64_t mio_now();
+uint64_t mio_time_seconds(uint64_t time_in_nanosecs);
+uint64_t mio_time_nanoseconds(uint64_t time_in_nanosecs);
 
 uint64_t mio_byteorder_cpu_to_be64(uint64_t cpu_64bits);
 uint64_t mio_byteorder_be64_to_cpu(uint64_t big_endian_64bits);

--- a/src/mio_telemetry.h
+++ b/src/mio_telemetry.h
@@ -120,25 +120,66 @@ struct mio_telemetry_rec_ops {
 	
 };
 
-extern struct mio_telemetry_rec_ops mio_motr_addb_rec_ops;
+struct mio_telemetry_conf {
+	enum mio_telemetry_store_type mtc_type;
+	/* Prefix added to the beginning of a telemetry record. */
+	char *mtc_prefix;
+	bool mtc_is_parser;
+	void *mtc_store_conf;
+};
 
-int mio_telemetry_array_advertise(char *topic,
-				  enum mio_telemetry_type type,
-				  int nr_elms, ...);
+extern struct mio_telemetry_rec_ops mio_motr_addb_rec_ops;
+extern struct mio_telemetry_rec_ops mio_telem_log_rec_ops;
+
+/**
+ * MIO telemetry APIs.
+ *
+ * (1) Initialise and finalise telemetry subsystem.
+ * mio_telemetry_init() and mio_telemetry_fini().
+ *
+ * @param conf Telemetry configuration parameters, including the type
+ * of telemetry store and store specific parameters. For example, if
+ * MIO_TM_ST_LOG is selected as telemetry backend store. The caller
+ * sets the mio_telemetry_conf::mtc_store_conf to the directory of log
+ * files.
+ * @return = 0 for success, anything else for an error.
+ *
+ * (2) Output and store telemetry a record: mio_telemetry_advertise()
+ * and mio_telemetry_array_advertise()
+ * mio_telemetry_array_advertise() is a wrapper function of
+ * mio_telemetry_advertise() for an array of data.
+ *
+ * @param topic. The `topic` string is used to identify where the
+ * record is created and its purpose.
+ * @param type Data value type, see `enum mio_telemetry_type` for details.
+ * @param value Pointer to data value.
+ * @return = 0 for success, anything else for an error.
+ *
+ * (3) Parse a record.
+ * mio_telemetry_parse()
+ *
+ * @param sp. Pointer to a telemetry store. For a parser, set
+ * mio_telemetry_store::mts_parse_stream to the input telemetry stream.
+ * For example, the parse stream for log is set to the file stream of
+ * the log file.
+ * @param rec[out] The pointer to the decoded record.   
+ * @return = 0 for success, anything else for an error.
+ */
 int mio_telemetry_advertise(const char *topic,
 			   enum mio_telemetry_type type,
 			   void *value);
+int mio_telemetry_array_advertise(char *topic,
+				  enum mio_telemetry_type type,
+				  int nr_elms, ...);
 int mio_telemetry_parse(struct mio_telemetry_store *sp,
 			struct mio_telemetry_rec *rec);
 
-int mio_telemetry_init(enum mio_telemetry_store_type type);
+int mio_telemetry_init(struct mio_telemetry_conf *conf);
 void mio_telemetry_fini();
 
 /* Helper functions. */
-int mio_telemetry_value_len(enum mio_telemetry_type type, void *value);
-int mio_telemetry_rec_len(const char *topic,
-			  enum mio_telemetry_type type,
-			  void *value);
+int mio_telemetry_alloc_value(enum mio_telemetry_type type, void **value);
+
 #endif
 
 /*

--- a/src/telemetry_log.c
+++ b/src/telemetry_log.c
@@ -1,0 +1,510 @@
+/* -*- C -*- */
+/*
+ * Copyright: (c) 2020 - 2021 Seagate Technology LLC and/or its its Affiliates,
+ * All Rights Reserved
+ *
+ * This software is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+
+#include "logger.h"
+#include "mio_internal.h"
+#include "mio_telemetry.h"
+
+/**
+ * Notes for storing and parsing telemetry records as MIO log entry.
+ *
+ * (1) MIO configuration yaml file has an option to select different
+ *     telemetry backend type. Set to LOG if text-based logging is
+ *     preferred.
+ *
+ * (2) To make the log entry readable, the following record format is used:
+ *
+ *     [TELEM] TIMESTAMP MIO_TELEMETRY_TOPIC DATA_TYPE VALUES
+ *
+ *     in which DATA_TYPE is the text string representing data type. 
+ */
+
+char *telem_data_type_names[] = {
+	[MIO_TM_TYPE_UINT16] = "UINT16",
+	[MIO_TM_TYPE_UINT32] = "UINT32",
+	[MIO_TM_TYPE_UINT64] = "UINT64",
+	[MIO_TM_TYPE_TIMESPAN] = "TIMESPAN",
+	[MIO_TM_TYPE_TIMEPOINT] = "TIMEPOINT",
+	[MIO_TM_TYPE_STRING] = "STRING",
+	[MIO_TM_TYPE_ARRAY_UINT16] = "ARRAY_UINT16",
+	[MIO_TM_TYPE_ARRAY_UINT32] = "ARRAY_UINT32",
+	[MIO_TM_TYPE_ARRAY_UINT64] = "ARRAY_UINT64",
+};
+
+static void telem_log_skip_delimiter(char **buf)
+{
+	int len;
+	char *cursor;
+
+	len = strlen(*buf);
+	cursor = *buf;
+	while (isspace(*cursor)) {
+		cursor++;
+		if (cursor - (*buf) >= len)
+			break;
+	}
+	*buf = cursor;
+}
+
+static void telem_log_jump_to_delimiter(char **buf)
+{
+	int len;
+	char *cursor;
+
+	len = strlen(*buf);
+	cursor = *buf;
+	while (!isspace(*cursor) && *cursor != '\n') {
+		cursor++;
+		if (cursor - (*buf) >= len)
+			break;
+	}
+	*buf = cursor;
+}
+
+static void telem_log_rec_get_string(char **rec, char **string)
+{
+	uint8_t len;
+	char *end_of_str;
+
+	*string = NULL;
+
+	telem_log_skip_delimiter(rec);
+	end_of_str = *rec;
+	telem_log_jump_to_delimiter(&end_of_str);
+	len = end_of_str - *rec;
+
+	/* The string stored doesn't include '\0', add it back. */
+	*string = mio_mem_alloc(len + 1);
+	if (*string == NULL)
+		return;
+	mio_mem_copy(*string, *rec, len);
+	(*string)[len] = '\0';
+	*rec += len;
+}
+
+static void
+telem_log_rec_get_scalar(char **rec, enum mio_telemetry_type type, void *val)
+{
+	int rc;
+	char val_str[32];
+	char *end_of_val;
+	int val_len;
+
+	end_of_val = *rec;
+	telem_log_skip_delimiter(&end_of_val);
+	telem_log_jump_to_delimiter(&end_of_val);
+	val_len = end_of_val - *rec;
+	if (val_len <= 0 || val_len > 32) {
+		fprintf(stderr, "Value is too big!\n");
+		goto exit;		
+	}
+	mio_mem_copy(val_str, *rec, end_of_val - (*rec));
+
+	switch (type) {
+	case MIO_TM_TYPE_UINT16:
+		*(uint16_t *)val = (uint16_t)atoi(val_str);
+		break;
+	case MIO_TM_TYPE_UINT32:
+		*(uint32_t *)val = (uint32_t)atoi(val_str);
+		break;
+	case MIO_TM_TYPE_UINT64:
+	case MIO_TM_TYPE_TIMESPAN:
+	case MIO_TM_TYPE_TIMEPOINT:
+		rc = sscanf(val_str, "%"SCNu64"", (uint64_t *)val);
+		if (rc <= 0)
+			fprintf(stderr, "Can't parse uint64 value!\n");
+		break;
+	default:
+		fprintf(stderr, "Wrong data type for scalar value!\n");
+		break;
+	}
+
+exit:
+	*rec = end_of_val;
+}
+
+static void telem_log_rec_get_u16(char **rec, uint16_t *val)
+{
+	telem_log_rec_get_scalar(rec, MIO_TM_TYPE_UINT16, val);
+}
+
+static void telem_log_rec_get_u32(char **rec, uint32_t *val)
+{
+	telem_log_rec_get_scalar(rec, MIO_TM_TYPE_UINT32, val);
+}
+
+static void telem_log_rec_get_u64(char **rec, uint64_t *val)
+{
+	telem_log_rec_get_scalar(rec, MIO_TM_TYPE_UINT64, val);
+}
+
+static int
+telem_log_rec_get_array(char **rec, enum mio_telemetry_type type,
+			struct mio_telemetry_array *array)
+{
+	int i;
+	uint16_t nr_elms;
+	uint16_t nr_bytes;
+	void *elms;
+
+	telem_log_rec_get_u16(rec, &nr_elms);
+	if (type == MIO_TM_TYPE_ARRAY_UINT16)
+		nr_bytes = nr_elms * 2; 
+	else if (type == MIO_TM_TYPE_ARRAY_UINT32)
+		nr_bytes = nr_elms * 4; 
+	else if (type == MIO_TM_TYPE_ARRAY_UINT64)
+		nr_bytes = nr_elms * 8; 
+	else
+		return -EINVAL;
+
+	elms = mio_mem_alloc(nr_bytes);
+	if (elms == NULL)
+		return -ENOMEM;
+
+	for (i = 0; i < nr_elms; i++) {
+		if (type == MIO_TM_TYPE_ARRAY_UINT16)
+			telem_log_rec_get_u16(rec, &((uint16_t *)elms)[i]);
+		else if (type == MIO_TM_TYPE_ARRAY_UINT32)
+			telem_log_rec_get_u32(rec, &((uint32_t *)elms)[i]);
+		else if (type == MIO_TM_TYPE_ARRAY_UINT64)
+			telem_log_rec_get_u64(rec, &((uint64_t *)elms)[i]);
+	}
+	array->mta_nr_elms = nr_elms;
+	array->mta_elms = elms;
+	return 0;
+}
+
+static int
+telem_log_rec_get_value(char **rec, enum mio_telemetry_type type, void **value)
+{
+	int rc = 0;
+
+	*value = NULL;
+	if (type == MIO_TM_TYPE_NONE)
+		return 0;
+
+	rc = mio_telemetry_alloc_value(type, value);
+	if (rc < 0)
+		return rc;
+
+	switch (type) {
+	case MIO_TM_TYPE_UINT16:
+		telem_log_rec_get_u16(rec, (uint16_t *)(*value));
+		break;
+	case MIO_TM_TYPE_UINT32:
+		telem_log_rec_get_u32(rec, (uint32_t *)(*value));
+		break;
+	case MIO_TM_TYPE_UINT64:
+	case MIO_TM_TYPE_TIMESPAN:
+	case MIO_TM_TYPE_TIMEPOINT:
+		telem_log_rec_get_u64(rec, (uint64_t *)(*value));
+		break;
+	case MIO_TM_TYPE_ARRAY_UINT16:
+	case MIO_TM_TYPE_ARRAY_UINT32:
+	case MIO_TM_TYPE_ARRAY_UINT64:
+		telem_log_rec_get_array(
+			rec, type, (struct mio_telemetry_array *)(*value));
+		break;
+	default:
+		rc = -EINVAL;
+		break;
+	}
+
+	return rc;
+}
+
+static int
+telem_log_rec_get_value_type(char **rec, enum mio_telemetry_type *type)
+{
+	int i;
+	char *type_str;
+
+	telem_log_rec_get_string(rec, &type_str);
+	if (type_str == NULL)
+		return -ENOMEM;
+	for (i = MIO_TM_TYPE_UINT16; i < MIO_TM_TYPE_NR; i++)
+		if (!strcmp(type_str, telem_data_type_names[i]))
+			break;
+	if (i == MIO_TM_TYPE_NR)
+		return -EINVAL;
+
+	mio_mem_free(type_str);
+	*type = i;
+	return 0;
+}
+
+static void telem_log_rec_add_string(char **rec, const char *string)
+{
+	uint8_t str_len;
+
+	assert(string != NULL);
+	str_len = strlen(string);
+	mio_mem_copy(*rec, (char *)string, str_len);
+	*rec += str_len;
+	**rec = ' ';
+	*rec += 1;
+}
+
+static void telem_log_rec_add_u16(char **rec, uint16_t val)
+{
+	char val_str[16];
+
+	sprintf(val_str, "%u", val);
+	telem_log_rec_add_string(rec, val_str);
+}
+
+static void telem_log_rec_add_u32(char **rec, uint32_t val)
+{
+	char val_str[32];
+
+	sprintf(val_str, "%u", val);
+	telem_log_rec_add_string(rec, val_str);
+}
+
+static void telem_log_rec_add_u64(char **rec, uint64_t val)
+{
+	char val_str[64];
+
+	sprintf(val_str, "%"PRIu64"", val);
+	telem_log_rec_add_string(rec, val_str);
+}
+
+static int
+telem_log_rec_add_array(char **rec, enum mio_telemetry_type type, void *value)
+{
+	int i;
+	int nr_elms = 0;
+	void *elms;
+	struct mio_telemetry_array *arr;
+
+	assert(value != NULL && *rec != NULL);
+	arr = (struct mio_telemetry_array *)value;
+	nr_elms = arr->mta_nr_elms;
+
+	/* Number of elements. */
+	telem_log_rec_add_u16(rec, (uint16_t)nr_elms);
+
+	/* Elements */
+	elms = arr->mta_elms;
+	for (i = 0; i < nr_elms; i++) {
+		if (type == MIO_TM_TYPE_ARRAY_UINT16)
+			telem_log_rec_add_u16(rec, ((uint16_t *)elms)[i]);
+		else if (type == MIO_TM_TYPE_ARRAY_UINT32)
+			telem_log_rec_add_u32(rec, ((uint32_t *)elms)[i]);
+		else if (type == MIO_TM_TYPE_ARRAY_UINT64)
+			telem_log_rec_add_u64(rec, ((uint64_t *)elms)[i]);
+	}
+
+	return 0;
+}
+
+static int
+telem_log_rec_add_value(char **rec, enum mio_telemetry_type type, void *value)
+{
+	int rc = 0;
+
+	assert(type > MIO_TM_TYPE_INVALID && type < MIO_TM_TYPE_NR);
+
+	switch (type) {
+	case MIO_TM_TYPE_UINT16:
+		telem_log_rec_add_u16(rec, *((uint16_t *)value));
+		break;
+	case MIO_TM_TYPE_UINT32:
+		telem_log_rec_add_u32(rec, *((uint32_t *)value));
+		break;
+	case MIO_TM_TYPE_TIMEPOINT:
+	case MIO_TM_TYPE_TIMESPAN:
+	case MIO_TM_TYPE_UINT64:
+		telem_log_rec_add_u64(rec, *((uint64_t *)value));
+		break;
+	case MIO_TM_TYPE_ARRAY_UINT16:
+	case MIO_TM_TYPE_ARRAY_UINT32:
+	case MIO_TM_TYPE_ARRAY_UINT64:
+		rc = telem_log_rec_add_array(rec, type, value);
+		break;
+	case MIO_TM_TYPE_NONE:
+		/* Do nothing. */
+		break;
+	default:
+		telem_log_rec_add_u64(rec, *((uint64_t *)value));
+		break;
+	}
+
+	return rc;
+}
+
+static int
+mio_telem_log_encode(const struct mio_telemetry_rec *rec, char **buf, int *len)
+{
+	int rc = 0;
+	int rec_len;
+	char *cursor;	
+	const char *topic;
+	enum mio_telemetry_type type;
+	void *value;
+	char *rec_buf;
+
+	topic = rec->mtr_topic;
+	type = rec->mtr_type;
+	value = rec->mtr_value;
+	if (type <= MIO_TM_TYPE_INVALID || type >= MIO_TM_TYPE_NR)
+		return -EINVAL;
+
+	rec_buf = mio_mem_alloc(MIO_LOG_MAX_REC_LEN);
+	if (rec_buf == NULL)
+		return -ENOMEM;
+	cursor = rec_buf;
+
+	/* Topic. */
+	telem_log_rec_add_string(&cursor, topic);
+
+	/* Type. */
+	telem_log_rec_add_string(&cursor, telem_data_type_names[type]);
+
+	/* Value. */
+	rc = telem_log_rec_add_value(&cursor, type, value);
+	if (rc < 0) {
+		mio_mem_free(rec_buf);
+		rec_buf = NULL;
+		goto exit;
+	}
+
+	rec_len = strlen(rec_buf) + 1;
+	rec_buf = realloc(rec_buf, rec_len);
+	*len = rec_len;
+exit:
+	*buf = rec_buf;
+	return rc;
+
+}
+
+static int mio_telem_log_decode(const char *buf, const char *head,
+				const char *tail, struct mio_telemetry_rec *rec)
+{
+	int rc = 0;
+	char *cursor;	
+	char *topic = NULL;
+	enum mio_telemetry_type type = MIO_TM_TYPE_INVALID;
+	void *value = NULL;
+
+	if (buf == NULL || head == NULL || rec == NULL)
+		return -EINVAL;
+
+	/* Time string. */
+	rec->mtr_time_str = mio_mem_alloc(strlen(head) + 1);
+	if (rec->mtr_time_str == NULL)
+		return -ENOMEM;
+	mio_mem_copy(rec->mtr_time_str, (char *)head, strlen(head) + 1);
+
+	/* Topic. */
+	cursor = (char *)buf;
+	telem_log_rec_get_string(&cursor, &topic);
+
+	/* Type. */
+	telem_log_rec_get_value_type(&cursor, &type);
+
+	/* Value. */
+	rc = telem_log_rec_get_value(&cursor, type, &value);
+	if (rc < 0) {
+		mio_mem_free(rec->mtr_time_str);
+		mio_mem_free(topic);
+		return rc;
+	}
+
+	rec->mtr_topic = topic;
+	rec->mtr_type = type;
+	rec->mtr_value = value;
+
+	return rc;
+}
+
+static int mio_telem_log_store(void *dump_stream, const char *buf, int len)
+{
+	mio_log(MIO_TELEMETRY, "%s\n", buf);
+	return 0;
+}
+
+static int mio_telem_log_load(void *parse_stream, char **rec_buf,
+			      char **head, char **tail)
+{
+	int rc = 0;
+	int time_str_len = 0;
+	size_t line_len = 0;
+	size_t line_cap = 0;
+	char *time_str = NULL;
+	char *line = NULL;
+	char *clock;
+	char *rec = NULL;
+	FILE *fp = (FILE *)parse_stream;
+
+	assert(fp != NULL);
+
+	while ((line_len = getline(&line, &line_cap, fp)) != EOF) {
+		/* Skip those lines not starting with `[telem]`. */
+		if (strstr(line, mio_log_levels[MIO_TELEMETRY].name) == NULL)
+			continue;
+
+		clock = line + strlen(mio_log_levels[MIO_TELEMETRY].name) + 2;
+		telem_log_skip_delimiter(&clock);
+		rec = clock;
+		telem_log_jump_to_delimiter(&rec);
+		time_str_len = rec - clock;
+
+		/* Copy time string and add '\0' at the end. */
+		time_str = mio_mem_alloc(time_str_len + 1);
+		if (time_str == NULL)
+			break;
+		mio_mem_copy(time_str, clock, time_str_len);
+		time_str[time_str_len] = '\0';
+		break;
+	}
+	if (line_len == EOF)
+		return EOF;
+	if (time_str == NULL)
+		return -ENOMEM;
+
+	*rec_buf = mio_mem_alloc(line_len - time_str_len);
+	if (*rec_buf == NULL)
+		goto exit;
+	mio_mem_copy(*rec_buf, rec, line_len - time_str_len);
+	*head = time_str;
+
+exit:
+	mio_mem_free(line);
+	return rc;
+
+}
+
+struct mio_telemetry_rec_ops mio_telem_log_rec_ops = {
+        .mtro_encode         = mio_telem_log_encode,
+        .mtro_decode         = mio_telem_log_decode,
+        .mtro_store          = mio_telem_log_store,
+        .mtro_load           = mio_telem_log_load
+};
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ *
+ */

--- a/src/utils.c
+++ b/src/utils.c
@@ -55,6 +55,16 @@ uint64_t mio_now()
         return tv.tv_sec * TIME_ONE_SECOND + tv.tv_usec * 1000;
 }
 
+uint64_t mio_time_seconds(uint64_t time_in_nanosecs)
+{
+	return time_in_nanosecs / TIME_ONE_SECOND;
+}
+
+uint64_t mio_time_nanoseconds(uint64_t time_in_nanosecs)
+{
+	return time_in_nanosecs % TIME_ONE_SECOND;
+}
+
 uint64_t mio_byteorder_cpu_to_be64(uint64_t cpu_64bits)
 {
         return __cpu_to_be64(cpu_64bits);

--- a/telemetry/mio_telemetry_parser.c
+++ b/telemetry/mio_telemetry_parser.c
@@ -18,7 +18,7 @@
 
 static void usage()
 {
-	fprintf(stderr, "Usage: mio_telemetry_parser files.\n");
+	fprintf(stderr, "Usage: mio_telemetry_parser files [addb | log].\n");
 }
 
 enum {
@@ -138,8 +138,10 @@ int main(int argc, char **argv)
 {
 	char *fname;
 	FILE *fp;
+	struct mio_telemetry_conf conf;
+	enum mio_telemetry_store_type type;
 
-	if (argc < 2) {
+	if (argc < 3) {
 		usage();
 		exit(EXIT_FAILURE);
 	}
@@ -150,7 +152,21 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	mio_telemetry_init(MIO_TM_ST_ADDB);
+	if (!strcmp(argv[2], "addb"))
+		type = MIO_TM_ST_ADDB;
+	if (!strcmp(argv[2], "log"))
+		type = MIO_TM_ST_LOG;
+	else {
+		fprintf(stderr,
+			"Unsupported telemetry store type: %s.",
+			argv[2]);
+		usage();
+		exit(EXIT_FAILURE);
+	}
+	conf.mtc_type = type;
+	conf.mtc_is_parser = true;
+
+	mio_telemetry_init(&conf);
 	parse(fp);
 	mio_telemetry_fini();
 

--- a/tests/mio_config.yaml
+++ b/tests/mio_config.yaml
@@ -35,12 +35,19 @@
 
 # 2. Virtual machine configurations for development/test.
 
+## Example for using log file as telemetry backend.
+#MIO_CONFIG:
+#  MIO_LOG_DIR: /var/log/mio
+#  MIO_LOG_LEVEL: MIO_DEBUG 
+#  MIO_DRIVER: MOTR
+#  MIO_TELEMETRY_STORE: LOG
+
 #MIO_Config_Sections: [MIO_CONFIG, MOTR_CONFIG]
 MIO_CONFIG:
-  MIO_LOG_FILE:
+  MIO_LOG_DIR:
   MIO_LOG_LEVEL: MIO_DEBUG 
   MIO_DRIVER: MOTR
-#  MIO_TELEMETRY_STORE: ADDB
+  MIO_TELEMETRY_STORE: ADDB
 
 MOTR_CONFIG:
   MOTR_USER_GROUP: motr 


### PR DESCRIPTION
- Allow user to select telemetry backend stores by setting
  MIO_TELEMETRY_STORE in MIO configuration yaml file.

  If a user would like to turn off telemetry, it can be done by
  not setting any backend store type to MIO_TELEMETRY_STORE. Internally,
  the store type is set to MIO_TM_ST_NONE in this case.

- Define format for MIO log file's name under specified log directory.
  log's file name: appname-pid-YY-MM-DD-hh-mm-ss.log

- Define telemetry record format in a log file.

  [telem] timestamp topic data_type value
  where timestamp uses ISO8601 formate: YY-MM-DD-hh:mm:ss:ns
  data_type is displayed as a string, such as "UINT64"

- If log file is configured as telemetry backend, the telemetry sub-system
  can be used without MIO object store backend such as motr. This allows
  some applications which don't need MIO's object and key-value store
  functionalities can still use telemetry sub-system.
  examples/mio_telemetry_test.c shows how to do it.

  Of course, a telemetry parser doesn't need MIO object and key-value store
  neither.

Signed-off-by: Sining Wu <sining.wu@seagate.com>