### PR TITLE
ADDB records generated by worker threads are lost. For example, it ha…

### DIFF
--- a/src/driver_motr.c
+++ b/src/driver_motr.c
@@ -209,6 +209,7 @@ static int mio_motr_thread_init(struct mio_thread *thread)
 
 static void mio_motr_thread_fini(struct mio_thread *thread)
 {
+	m0_addb2_force_all();
 	m0_thread_shun();
 	mio_mem_free(thread->mt_drv_thread);
 }

--- a/src/mio_telemetry.c
+++ b/src/mio_telemetry.c
@@ -266,11 +266,13 @@ int mio_telemetry_init(struct mio_telemetry_conf *conf)
 	if (type == MIO_TM_ST_NONE)
 		mio_telem_rec_ops = NULL;
 	else if (type == MIO_TM_ST_ADDB) {
-		rc = mio_instance_check();
-		if (rc < 0)
-			return rc;
-		if (mio_instance->m_driver_id != MIO_MOTR)
-			return -EINVAL;
+		if (!conf->mtc_is_parser) {
+			rc = mio_instance_check();
+			if (rc < 0)
+				return rc;
+			if (mio_instance->m_driver_id != MIO_MOTR)
+				return -EINVAL;
+		}
 		mio_telem_rec_ops = &mio_motr_addb_rec_ops;
 	} else if (type == MIO_TM_ST_LOG) {
 		if (!conf->mtc_is_parser && mio_log_file == NULL) {

--- a/telemetry/mio_addb_parser.sh
+++ b/telemetry/mio_addb_parser.sh
@@ -6,7 +6,7 @@ addb=$1
 if [ ! -f $addb ]; then
 	echo "Can't find ADDB dump file!"
 	echo "Usage: $ mio_addb_parser addb_dump_file"
-	return 1
+	exit 1
 fi
 
 # Filter out those MIO records.
@@ -19,10 +19,10 @@ grep -E $mio_addb_id $addb > $tmp
 parser=$dir/mio_telemetry_parser
 if [ ! -f $parser ]; then
 	echo "Can't find MIO telemetry parser!"
-	return 1
+	exit 1
 fi
-eval "$parser $tmp >> $addb"
+eval "$parser $tmp 'addb' >> $addb"
 if [ $? -ne 0 ]; then
 	echo "Failed to parse MIO telemetry records!"
-	return 1
+	exit 1
 fi

--- a/telemetry/mio_telemetry_parser.c
+++ b/telemetry/mio_telemetry_parser.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 
 	if (!strcmp(argv[2], "addb"))
 		type = MIO_TM_ST_ADDB;
-	if (!strcmp(argv[2], "log"))
+	else if (!strcmp(argv[2], "log"))
 		type = MIO_TM_ST_LOG;
 	else {
 		fprintf(stderr,


### PR DESCRIPTION
…ppens when

running mio_io_perf.

- This is a bug in motr where a worker thread (main thread is the one call
  m0_client_init()) doesn't push buffer into stob when it exits. The workaround
  is to force flushing the ADDB records by explicitly calling m0_addb2_force_all().

- Also fix ADDB parser script, mio_addb_parser.sh, to work with new version of
  mio_telemetry_parser (modified after log backend was introduced.).

Signed-off-by: Sining Wu <sining.wu@seagate.com>