### PR TITLE
Build standalone telemetry library without IO, Motr and ADDB.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,37 +63,43 @@ EXTRA_DIST = autogen.sh
 CLEANFILES =
 
 #-------------------------------------------------------------------------------
-#                                  MIO Libraries                               #
+#                                  MIO Library                                 #
 #-------------------------------------------------------------------------------
 
-lib_LTLIBRARIES          += lib/libmio.la
-lib_libmio_la_CPPFLAGS  = -DM0_TARGET='libmotr' $(AM_CPPFLAGS)
-lib_libmio_la_LDFLAGS   = -version-info @LT_VERSION@ $(AM_LDFLAGS)
+lib_LTLIBRARIES         += lib/libmio.la
+lib_libmio_la_CPPFLAGS   = -DM0_TARGET='libmotr' -DMIO_MOTR_ADDB $(AM_CPPFLAGS)
+lib_libmio_la_LDFLAGS    = -version-info @LT_VERSION@ $(AM_LDFLAGS)
 #lib_libmio_la_LIBADD    = @MOTR_LIBS@ @YAML_LIBS@ 
-lib_libmio_la_LIBADD    = -lmotr -lyaml 
-
-lib_libmio_la_SOURCES =
+lib_libmio_la_LIBADD     = -lmotr -lyaml 
+lib_libmio_la_SOURCES    =
 
 # install directory for public libmio headers
 mio_includedir             = $(includedir)/mio
-
 nobase_mio_include_HEADERS = config.h
 
-include $(top_srcdir)/src/Makefile.sub
+#-------------------------------------------------------------------------------
+#                     MIO Telemetry Library (No IO, MOTR and ADDB)             #
+#-------------------------------------------------------------------------------
 
+lib_LTLIBRARIES          += lib/libtelem.la
+lib_libtelem_la_CPPFLAGS  = $(AM_CPPFLAGS)
+lib_libtelem_la_LDFLAGS   = -version-info @LT_VERSION@ $(AM_LDFLAGS)
+lib_libtelem_la_LIBADD    = 
+lib_libtelem_la_SOURCES   =
+
+# install directory for public libtelem headers
+telem_includedir             = $(includedir)/telem
+nobase_telem_include_HEADERS =
+
+#-------------------------------------------------------------------------------
+#                        Sources for Libraries                                 #
+#-------------------------------------------------------------------------------
+include $(top_srcdir)/src/Makefile.sub
 
 #-------------------------------------------------------------------------------
 #                                 Tests                                        #
 #-------------------------------------------------------------------------------
 include $(top_srcdir)/tests/Makefile.sub
-
-#-------------------------------------------------------------------------------
-#                                 Telemetry                                    #
-#-------------------------------------------------------------------------------
-noinst_PROGRAMS                   += telemetry/mio_telemetry_parser
-telemetry_mio_telemetry_parser_CPPFLAGS = -DMIO_TARGET='mio_telemetry_parser' $(AM_CPPFLAGS)
-telemetry_mio_telemetry_parser_LDADD    = $(top_builddir)/lib/libmio.la
-include $(top_srcdir)/telemetry/Makefile.sub
 
 #-------------------------------------------------------------------------------
 #                                 MIO Examples                                 #
@@ -117,7 +123,6 @@ noinst_PROGRAMS                   += examples/mio_comp_obj_example
 noinst_PROGRAMS                   += examples/mio_rw_threads 
 noinst_PROGRAMS                   += examples/mio_rw_lock 
 noinst_PROGRAMS                   += examples/mio_hsm 
-noinst_PROGRAMS                   += examples/mio_telemetry_test 
 noinst_PROGRAMS                   += examples/mio_io_perf
 
 examples_mio_cat_CPPFLAGS = -DMIO_TARGET='mio_cat' $(AM_CPPFLAGS)
@@ -165,9 +170,6 @@ examples_mio_kvs_del_pairs_LDADD    = $(top_builddir)/lib/libmio.la
 examples_mio_comp_obj_example_CPPFLAGS = -DMIO_TARGET='mio_comp_obj_example' $(AM_CPPFLAGS)
 examples_mio_comp_obj_example_LDADD    = $(top_builddir)/lib/libmio.la
 
-examples_mio_telemetry_test_CPPFLAGS = -DMIO_TARGET='mio_telemetry_test' $(AM_CPPFLAGS)
-examples_mio_telemetry_test_LDADD    = $(top_builddir)/lib/libmio.la
-
 examples_mio_rw_threads_CPPFLAGS = -DMIO_TARGET='mio_rw_threads' $(AM_CPPFLAGS)
 examples_mio_rw_threads_LDADD    = $(top_builddir)/lib/libmio.la -lpthread -lcrypto -lssl
 
@@ -181,6 +183,19 @@ examples_mio_io_perf_CPPFLAGS = -DMIO_TARGET='mio_io_perf' $(AM_CPPFLAGS)
 examples_mio_io_perf_LDADD    = $(top_builddir)/lib/libmio.la -ledit
 
 include $(top_srcdir)/examples/Makefile.sub
+
+#-------------------------------------------------------------------------------
+#                  Telemetry Examples and Sample Workflow                      #
+#-------------------------------------------------------------------------------
+noinst_PROGRAMS                   += examples/mio_telemetry_test 
+examples_mio_telemetry_test_CPPFLAGS = -DMIO_TARGET='mio_telemetry_test' $(AM_CPPFLAGS)
+examples_mio_telemetry_test_LDADD    = $(top_builddir)/lib/libtelem.la
+
+
+noinst_PROGRAMS                   += telemetry/mio_telemetry_parser
+telemetry_mio_telemetry_parser_CPPFLAGS = -DMIO_TARGET='mio_telemetry_parser' $(AM_CPPFLAGS)
+telemetry_mio_telemetry_parser_LDADD    = $(top_builddir)/lib/libmio.la
+include $(top_srcdir)/telemetry/Makefile.sub
 
 #-------------------------------------------------------------------------------
 #                                 Build rules                                  # 

--- a/examples/Makefile.sub
+++ b/examples/Makefile.sub
@@ -27,9 +27,6 @@ examples_mio_rw_lock_SOURCES = examples/mio_rw_lock.c \
 examples_mio_hsm_SOURCES = examples/mio_hsm.c examples/obj.c \
 	  examples/obj_io_poll.c examples/helpers.c
 
-examples_mio_telemetry_test_SOURCES = examples/mio_telemetry_test.c examples/obj.c \
-	  examples/helpers.c
-
 examples_mio_io_perf_SOURCES = examples/mio_io_perf.c \
 	  examples/obj.c examples/obj_io_poll.c examples/obj_io_cbs.c\
 	  examples/helpers.c
@@ -73,4 +70,6 @@ examples_mio_kvs_list_SOURCES = examples/mio_kvs_list.c  examples/kvs.c \
 
 examples_mio_kvs_del_pairs_SOURCES = examples/mio_kvs_del_pairs.c  examples/kvs.c \
 	  examples/helpers.c 
+
+examples_mio_telemetry_test_SOURCES = examples/mio_telemetry_test.c
 

--- a/examples/mio_telemetry_test.c
+++ b/examples/mio_telemetry_test.c
@@ -9,12 +9,11 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "src/mio.h"
 #include "src/mio_telemetry.h"
-#include "obj.h"
-#include "helpers.h"
 
 /**
  * MIO telemetry tests with log as backend. The tests also
@@ -84,7 +83,8 @@ int main(int argc, char **argv)
 	telem_conf.mtc_is_parser = false;
 	rc = mio_telemetry_init(&telem_conf);
 	if (rc < 0) {
-		mio_cmd_error("Initialising MIO failed", rc);
+		fprintf(stderr, "%s: errno = %d, %s\n",
+			"Initialising MIO failed", rc, strerror(-rc));
 		exit(EXIT_FAILURE);
 	}
 

--- a/examples/obj.c
+++ b/examples/obj.c
@@ -27,8 +27,8 @@ int obj_alloc_iovecs(struct mio_iovec **data, uint64_t bcount,
 	struct mio_iovec *iovecs;
 	char *base;
 
-	iovecs = mio_mem_alloc(bcount * sizeof(*iovecs));
-	base = mio_mem_alloc(bcount * bsize);
+	iovecs = malloc(bcount * sizeof(*iovecs));
+	base = malloc(bcount * bsize);
 	if (iovecs == NULL || base == NULL) {
 		fprintf(stderr, "Can't allocate memory!\n");
 		rc = -ENOMEM;
@@ -47,15 +47,15 @@ int obj_alloc_iovecs(struct mio_iovec **data, uint64_t bcount,
 	return 0;
 
 error_exit:
-	mio_mem_free(base);
-	mio_mem_free(iovecs);
+	free(base);
+	free(iovecs);
 	return rc;
 }
 
 void obj_cleanup_iovecs(struct mio_iovec *data)
 {
-	mio_mem_free(data[0].miov_base);
-	mio_mem_free(data);
+	free(data[0].miov_base);
+	free(data);
 }
 
 int obj_read_data_from_file(FILE *fp, uint64_t bcount, uint64_t bsize,

--- a/src/Makefile.sub
+++ b/src/Makefile.sub
@@ -9,7 +9,8 @@ nobase_mio_include_HEADERS += src/mio.h \
 			      src/mio_telemetry.h \
 			      src/mio_internal.h \
 			      src/driver_motr.h \
-			      src/logger.h
+			      src/logger.h \
+			      src/utils.h
 
 lib_libmio_la_SOURCES += src/mio_conf.c src/logger.c src/utils.c \
 			 src/mio.c src/mio_driver.c src/hints.c \
@@ -17,3 +18,10 @@ lib_libmio_la_SOURCES += src/mio_conf.c src/logger.c src/utils.c \
 			 src/driver_motr.c src/driver_motr_obj.c \
 			 src/driver_motr_kvs.c src/driver_motr_comp_obj.c \
 			 src/driver_motr_addb.c
+
+nobase_telem_include_HEADERS += src/mio_telemetry.h \
+			        src/logger.h \
+			        src/utils.h
+
+lib_libtelem_la_SOURCES += src/logger.c src/utils.c \
+			   src/mio_telemetry.c src/telemetry_log.c

--- a/src/driver_motr.c
+++ b/src/driver_motr.c
@@ -17,6 +17,7 @@
 #include <uuid/uuid.h>
 
 #include "logger.h"
+#include "utils.h"
 #include "mio.h"
 #include "mio_internal.h"
 #include "driver_motr.h"

--- a/src/driver_motr_addb.c
+++ b/src/driver_motr_addb.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <addb2/addb2_internal.h>
 
+#include "utils.h"
 #include "mio_internal.h"
 #include "mio_telemetry.h"
 

--- a/src/driver_motr_comp_obj.c
+++ b/src/driver_motr_comp_obj.c
@@ -16,6 +16,7 @@
 #include "motr/idx.h"
 
 #include "logger.h"
+#include "utils.h"
 #include "mio.h"
 #include "mio_internal.h"
 #include "driver_motr.h"

--- a/src/driver_motr_kvs.c
+++ b/src/driver_motr_kvs.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 
 #include "logger.h"
+#include "utils.h"
 #include "mio.h"
 #include "mio_internal.h"
 #include "driver_motr.h"

--- a/src/driver_motr_obj.c
+++ b/src/driver_motr_obj.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 
 #include "logger.h"
+#include "utils.h"
 #include "mio.h"
 #include "mio_internal.h"
 #include "mio_telemetry.h"

--- a/src/hints.c
+++ b/src/hints.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 
 #include "logger.h"
+#include "utils.h"
 #include "mio.h"
 #include "mio_internal.h"
 

--- a/src/logger.c
+++ b/src/logger.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 
 #include "logger.h"
+#include "utils.h"
 #include "mio_internal.h"
 
 struct mio_log_level_name mio_log_levels[] = {

--- a/src/mio.c
+++ b/src/mio.c
@@ -13,6 +13,7 @@
 #include <assert.h>
 
 #include "logger.h"
+#include "utils.h"
 #include "mio_internal.h"
 #include "mio.h"
 #include "mio_telemetry.h"

--- a/src/mio_conf.c
+++ b/src/mio_conf.c
@@ -19,6 +19,7 @@
 #include "motr/client.h"
 
 #include "logger.h"
+#include "utils.h"
 #include "mio_internal.h"
 #include "mio.h"
 

--- a/src/mio_driver.c
+++ b/src/mio_driver.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <sys/errno.h>
 
+#include "utils.h"
 #include "mio_internal.h"
 #include "mio.h"
 #include "driver_motr.h"

--- a/src/mio_internal.h
+++ b/src/mio_internal.h
@@ -393,24 +393,6 @@ bool mio_hint_is_set(struct mio_hints *hints, int hint_key);
 
 int mio_obj_hotness_to_pool_idx(uint64_t hotness);
 
-void *mio_mem_alloc(size_t size);
-void mio_mem_free(void *p);
-void mio_memset(void *p, int c, size_t size);
-void mio_mem_copy(void *to, void *from, size_t size);
-
-uint64_t mio_now();
-uint64_t mio_time_seconds(uint64_t time_in_nanosecs);
-uint64_t mio_time_nanoseconds(uint64_t time_in_nanosecs);
-
-uint64_t mio_byteorder_cpu_to_be64(uint64_t cpu_64bits);
-uint64_t mio_byteorder_be64_to_cpu(uint64_t big_endian_64bits);
-uint16_t mio_byteorder_cpu_to_le16(uint16_t cpu_16bits);
-uint16_t mio_byteorder_le16_to_cpu(uint16_t le_16bits);
-uint32_t mio_byteorder_cpu_to_le32(uint32_t cpu_32bits);
-uint32_t mio_byteorder_le32_to_cpu(uint32_t le_32bits);
-uint64_t mio_byteorder_cpu_to_le64(uint64_t cpu_64bits);
-uint64_t mio_byteorder_le64_to_cpu(uint64_t le_64bits);
-
 int mio_conf_init(const char *config_file);
 void mio_conf_fini();
 bool mio_conf_default_pool_has_set();

--- a/src/mio_telemetry.h
+++ b/src/mio_telemetry.h
@@ -14,6 +14,7 @@
 #define __MIO_TELEMETRY_H__
 
 #include <stdio.h>
+#include <stdbool.h>
 
 /**
  * Telemetry interface provides MIO and its upper applications (by applications,

--- a/src/telemetry_log.c
+++ b/src/telemetry_log.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 
 #include "logger.h"
+#include "utils.h"
 #include "mio_internal.h"
 #include "mio_telemetry.h"
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -9,10 +9,12 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
+#include <stddef.h> 
 #include <sys/time.h>
 #include <asm/byteorder.h>
 
-#include "mio_internal.h"
+#include "utils.h"
 
 void *mio_mem_alloc(size_t size)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,44 @@
+/* -*- C -*- */
+/*
+ */
+
+#pragma once
+
+#ifndef __UTILS_H__
+#define __UTILS_H__
+
+#include <stdint.h>
+#include <stddef.h> 
+
+void *mio_mem_alloc(size_t size);
+void mio_mem_free(void *p);
+void mio_memset(void *p, int c, size_t size);
+void mio_mem_copy(void *to, void *from, size_t size);
+
+uint64_t mio_now();
+uint64_t mio_time_seconds(uint64_t time_in_nanosecs);
+uint64_t mio_time_nanoseconds(uint64_t time_in_nanosecs);
+
+uint64_t mio_byteorder_cpu_to_be64(uint64_t cpu_64bits);
+uint64_t mio_byteorder_be64_to_cpu(uint64_t big_endian_64bits);
+uint16_t mio_byteorder_cpu_to_le16(uint16_t cpu_16bits);
+uint16_t mio_byteorder_le16_to_cpu(uint16_t le_16bits);
+uint32_t mio_byteorder_cpu_to_le32(uint32_t cpu_32bits);
+uint32_t mio_byteorder_le32_to_cpu(uint32_t le_32bits);
+uint64_t mio_byteorder_cpu_to_le64(uint64_t cpu_64bits);
+uint64_t mio_byteorder_le64_to_cpu(uint64_t le_64bits);
+
+#endif /* __UTILS_H__ */
+
+/*
+ *  Local variables:
+ *  c-indentation-style: "K&R"
+ *  c-basic-offset: 8
+ *  tab-width: 8
+ *  fill-column: 80
+ *  scroll-step: 1
+ *  End:
+ */
+/*
+ * vim: tabstop=8 shiftwidth=8 noexpandtab textwidth=80 nowrap
+ */

--- a/tests/mio_run_tests.sh
+++ b/tests/mio_run_tests.sh
@@ -45,7 +45,6 @@ mio_all_tests="mio_obj_tests \
 	      mio_comp_obj_tests \
 	      mio_kvs_tests \
 	      mio_pool_tests \
-	      mio_pool_tests \
 	      mio_obj_hint_tests"
 
 mio_run_test()


### PR DESCRIPTION
Note: separately built telemetry library supports log file backend only.

Signed-off-by: Sining Wu <sining.wu@seagate.com>