### PR TITLE
Support for including mio in C++ builds with extern "C"

### DIFF
--- a/src/mio.h
+++ b/src/mio.h
@@ -28,7 +28,11 @@ struct mio_kvs_id;
  *   - mio_op_state defines operation states.
  *   - operations on ops such as initialisation and finalisation.
  */
+#ifdef __cplusplus
+enum mio_obj_opcode : int {
+#else
 enum mio_obj_opcode {
+#endif
 	MIO_OBJ_INVALID,
 	MIO_OBJ_CREATE,
 	MIO_OBJ_DELETE,

--- a/src/mio_internal.h
+++ b/src/mio_internal.h
@@ -29,7 +29,11 @@ struct mio_kv_pair;
 struct mio_hints;
 struct mio_thread;
 
+#ifdef __cplusplus
+enum mio_obj_opcode : int;
+#else
 enum mio_obj_opcode;
+#endif
 struct mio_obj_ext;
 struct mio_comp_obj_layer;
 struct mio_comp_obj_layout;


### PR DESCRIPTION
The change fixes a forward decleration of an enum `mio_obj_opcode`. 